### PR TITLE
Fix: Clean up keybindings and improve clarity

### DIFF
--- a/src/client/kotlin/code/cinnamon/CinnamonClient.kt
+++ b/src/client/kotlin/code/cinnamon/CinnamonClient.kt
@@ -24,7 +24,7 @@ class CinnamonClientMod : ClientModInitializer {
                 "key.cinnamon.open_gui",
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_RIGHT_SHIFT, // Right Shift to open GUI
-                "category.cinnamon"
+                "CinnamonClient" // Changed line
             )
         )
         

--- a/src/client/kotlin/code/cinnamon/keybindings/KeybindingManager.kt
+++ b/src/client/kotlin/code/cinnamon/keybindings/KeybindingManager.kt
@@ -5,10 +5,35 @@ import net.minecraft.client.util.InputUtil
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
 import org.lwjgl.glfw.GLFW
 
+/**
+ * Manages the registration and state of keybindings for the Cinnamon mod.
+ * 
+ * **Keybinding Naming and Usage:**
+ * - The `name` parameter provided to `registerKeybinding` (e.g., "cinnamon.toggle_flight")
+ *   serves as the internal identifier for that keybinding within this manager.
+ *   This exact `name` string must be used when calling `getKeybinding(name)`,
+ *   `isPressed(name)`, or `wasPressed(name)`.
+ *
+ * - The `category` parameter in `registerKeybinding` (which defaults to "CinnamonClient")
+ *   determines how keybindings are grouped in Minecraft's keybinding settings menu.
+ *
+ * - The actual string displayed in the Minecraft settings (e.g., "Open GUI" which might
+ *   correspond to a translation key like "key.cinnamon.open_gui") comes from the
+ *   first argument of the `net.minecraft.client.option.KeyBinding` constructor.
+ *   This is distinct from the internal `name` used by `KeybindingManager`.
+ *   For example, `KeyBinding("key.cinnamon.open_gui", ...)` uses "key.cinnamon.open_gui"
+ *   as its display/translation key.
+ *
+ * **Important for Custom Keybindings:**
+ *   If you register a keybinding (e.g., `KeybindingManager.registerKeybinding("my_module.my_action", ...)`),
+ *   you must check it using the same name: `KeybindingManager.isPressed("my_module.my_action")`.
+ *   Do not add prefixes like "key." when querying `KeybindingManager` unless the
+ *   keybinding was registered with that prefix in its `name`.
+ */
 object KeybindingManager {
     private val keybindings = mutableMapOf<String, KeyBinding>()
     
-    fun registerKeybinding(name: String, key: Int, category: String = "Cinnamon"): KeyBinding {
+    fun registerKeybinding(name: String, key: Int, category: String = "CinnamonClient"): KeyBinding {
         val keyBinding = KeyBindingHelper.registerKeyBinding(
             KeyBinding(
                 name,
@@ -37,7 +62,6 @@ object KeybindingManager {
     
     fun initialize() {
         // Register default keybindings here
-        registerKeybinding("cinnamon.open_gui", GLFW.GLFW_KEY_RIGHT_SHIFT)
         registerKeybinding("cinnamon.toggle_speed", GLFW.GLFW_KEY_V)
         registerKeybinding("cinnamon.toggle_flight", GLFW.GLFW_KEY_F)
         registerKeybinding("cinnamon.toggle_nofall", GLFW.GLFW_KEY_N)


### PR DESCRIPTION
Resolves issues with duplicate keybindings and incorrect category naming.

Changes include:
- Removed a redundant registration of "cinnamon.open_gui" from KeybindingManager, as "key.cinnamon.open_gui" is correctly registered and used in CinnamonClientMod. This addresses the "double keybinding" issue.
- Standardized the keybinding category display name to "CinnamonClient" as you requested. This change is applied to both the default category in KeybindingManager and the explicit registration in CinnamonClientMod.
- Added a comprehensive KDoc comment to KeybindingManager.kt. This documentation clarifies:
    - The distinction between the internal name used for KeybindingManager's functions (register, get, isPressed) and the translation key used for display in Minecraft's settings.
    - The role of the category string.
    - Best practices for registering and checking custom keybindings to avoid issues like those mentioned with "test example" keybinds (i.e., ensuring the name used for registration is the same as the name used for checking).

This should improve the organization of keybindings and provide better guidance for developers interacting with the keybinding system.